### PR TITLE
Use template rendering; required for Django 1.11

### DIFF
--- a/verified_email_field/templates/verified_email_field/field.html
+++ b/verified_email_field/templates/verified_email_field/field.html
@@ -1,0 +1,12 @@
+{% url 'verified-email-field:send' fieldsetup_id as send_url %} 
+<div class="input-group">
+{% for subwidget in widget.subwidgets %}
+    {% include subwidget.template_name with widget=subwidget %}
+{% endfor %}
+    <span class="input-group-btn">
+        <button class="btn btn-default" type="button" 
+            onclick="send_verification_code('{{name}}', '{{send_url}}')">
+            {{send_label}}
+        </button>
+    </span>
+</div>

--- a/verified_email_field/widgets.py
+++ b/verified_email_field/widgets.py
@@ -29,7 +29,16 @@ class VerifiedEmailWidget(MultiWidget):
             attrs = {}
         attrs['class'] = attrs['class'] + ' form-control' if 'class' in attrs else 'form-control'
         return super(VerifiedEmailWidget, self).render(name, value, attrs)
+    
+    def get_context(self, name, value, attrs):
+        context = super(VerifiedEmailWidget, self).get_context(name, value, attrs)
+        context['name'] = self.name
+        context['fieldsetup_id'] = self.fieldsetup_id
+        context['send_label'] = self.send_label
+        return context
 
+    # format_output is removed in Django 1.11
+    # It is only retained here for Django 1.8 compatibility
     def format_output(self, rendered_widgets):
         return ''.join((
             rendered_widgets[0],


### PR DESCRIPTION
Hello,

The django-verified-email-field is quite nice. However, when upgrading to Django 1.11 I noticed that it no longer renders properly. This is because the Django developers have chosen to remove the Widget.format_output() method in favor of template-based widget rendering. (Read more here: https://docs.djangoproject.com/en/2.0/releases/1.11/#template-widget-incompatibilities-1-11)

To resolve this, I have implemented a template for the widget to use, as well as get_context to supply the same variables that were supplied by format_output().

This pull request should resolve issue #6. I have not tested against Django 2.0, but my reading of the release notes indicates no backwards incompatible changes that should be relevant, so I suspect it resolves issue #7 as well. I have left format_output behind in order to support Django 1.8 for users who may still be on it for the next few months before its official support ends.

Hope it helps,
Joe