### PR TITLE
Ensure fieldsetup_id is always positive

### DIFF
--- a/verified_email_field/forms.py
+++ b/verified_email_field/forms.py
@@ -9,6 +9,7 @@ from .fieldsetup import VerifiedEmailFieldSetup, fieldsetups
 from .utils import get_code, send_code
 from .widgets import VerifiedEmailWidget
 
+import sys
 
 class SendForm(forms.Form):
     email = EmailField()
@@ -30,7 +31,7 @@ class VerifiedEmailField(MultiValueField):
     def __init__(self, required=True, fieldsetup_id=None, max_length=None,
                  email_label=_('e-mail'), send_label=_('send verification code'), code_label=_('verification code'),
                  **kwargs):
-        self.fieldsetup_id = fieldsetup_id or str(hash(self))
+        self.fieldsetup_id = fieldsetup_id or str(hash(self) + sys.maxsize + 1)
         self.fieldsetup = fieldsetups.setdefault(self.fieldsetup_id, VerifiedEmailFieldSetup(**kwargs))
         self.widget = VerifiedEmailWidget(
             send_label=send_label,


### PR DESCRIPTION
I have noticed that the hash algorithm used to generate the fieldsetup_id occasionally generates negative numbers, and this breaks the verified email field, either throwing a 500 Internal Server Error with debug mode off, or when using template rendering, simply not working when a user clicks the button.

I was in a big hurry while trying to fix this, so I simply changed the fieldsetup_id generation to always return a positive number. This is the patch I wrote at the time.

Now that I'm actually looking closer, I see the cause is that the url pattern for /send/ doesn't accept the - character. You could alternatively fix the issue by changing that. 