### PR TITLE
Remove jQuery/Ajax

### DIFF
--- a/verified_email_field/static/verified_email_field/send.js
+++ b/verified_email_field/static/verified_email_field/send.js
@@ -16,13 +16,29 @@ function getCookie(name) {
 
 
 function send_verification_code(id, url, message) {
-    var xhttp = new XMLHttpRequest();
-    xhttp.onreadystatechange = function() {
-        if (this.readyState == 4 && this.status == 200) {
-            if (xhttp.responseText) alert(xhttp.responseText);
-            document.getElementById(id.replace('_0', '_1')).focus();
-        }
-    };
-    xhttp.open("POST", url, true);
-    xhttp.send(`csrfmiddlewaretoken=${getCookie('csrftoken')}&email=${document.getElementById(id).value}`);
+    if (window.jQuery) {
+        $.ajax({
+            type: "POST",
+            url: url,
+            data: {
+                csrfmiddlewaretoken: getCookie('csrftoken'),
+                email: document.getElementById(id).value,
+            },
+            success: function(msg) {
+                if (message) alert(message);
+                document.getElementById(id.replace('_0', '_1')).focus();
+            },
+        });
+    }
+    else {
+        var xhttp = new XMLHttpRequest();
+        xhttp.onreadystatechange = function() {
+            if (this.readyState == 4 && this.status == 200) {
+                if (xhttp.responseText) alert(xhttp.responseText);
+                document.getElementById(id.replace('_0', '_1')).focus();
+            }
+        };
+        xhttp.open("POST", url, true);
+        xhttp.send(`csrfmiddlewaretoken=${getCookie('csrftoken')}&email=${document.getElementById(id).value}`);
+    }
 }

--- a/verified_email_field/static/verified_email_field/send.js
+++ b/verified_email_field/static/verified_email_field/send.js
@@ -3,7 +3,7 @@ function getCookie(name) {
     if (document.cookie && document.cookie !== '') {
         var cookies = document.cookie.split(';');
         for (var i = 0; i < cookies.length; i++) {
-            var cookie = jQuery.trim(cookies[i]);
+            var cookie = cookies[i].trim();
             // Does this cookie string begin with the name we want?
             if (cookie.substring(0, name.length + 1) === (name + '=')) {
                 cookieValue = decodeURIComponent(cookie.substring(name.length + 1));
@@ -16,16 +16,13 @@ function getCookie(name) {
 
 
 function send_verification_code(id, url, message) {
-    $.ajax({
-        type: "POST",
-        url: url,
-        data: {
-            csrfmiddlewaretoken: getCookie('csrftoken'),
-            email: document.getElementById(id).value,
-        },
-        success: function(msg) {
-            if (message) alert(message);
+    var xhttp = new XMLHttpRequest();
+    xhttp.onreadystatechange = function() {
+        if (this.readyState == 4 && this.status == 200) {
+            if (xhttp.responseText) alert(xhttp.responseText);
             document.getElementById(id.replace('_0', '_1')).focus();
-        },
-    });
+        }
+    };
+    xhttp.open("POST", url, true);
+    xhttp.send(`csrfmiddlewaretoken=${getCookie('csrftoken')}&email=${document.getElementById(id).value}`);
 }


### PR DESCRIPTION
jQuery and Ajax aren't necessary for this package. This will let users use django-verified-email-field without needing to import jQuery/Ajax.

EDIT: I didn't see this comment before I made this PR but I think this addresses https://github.com/misli/django-verified-email-field/issues/10#issuecomment-498171969